### PR TITLE
fix(ci): Use `--legacy` to deploy contracts

### DIFF
--- a/.github/workflows/solidity-deployment.yml
+++ b/.github/workflows/solidity-deployment.yml
@@ -83,6 +83,7 @@ jobs:
             --etherscan-api-key ${{ secrets.etherscan-api-key }} \
             --aws \
             --broadcast \
+            --legacy \
             --verify \
             --retries 20 \
             --chain ${{ inputs.network }} \


### PR DESCRIPTION
Temporarily fixes the deployment job by using `legacy` until foundry is bumped to the latest `alloy` version