### PR TITLE
feat: support CREATE2 deploys & contracts deployed in sub-calls

### DIFF
--- a/.github/workflows/solidity-deployment.yml
+++ b/.github/workflows/solidity-deployment.yml
@@ -108,6 +108,7 @@ jobs:
           gh release view $LATEST_TAG --json body -q .body >> releaseNotes.md 
           echo "# Deployment Information:" >> releaseNotes.md
           echo "## ${{ inputs.network }}" >> releaseNotes.md
-          (cat broadcast/${{ inputs.forge-deployment-script-file }}/${{ inputs.chain-id }}/${SIG_NAME}-latest.json | jq '.transactions | .[] | select(.transactionType == "CREATE") | "- [\(.contractName)](${{inputs.etherscan-url}}/address/\(.contractAddress)#code): \(.contractAddress)"' | tr -d '"' >> releaseNotes.md)
-            
+          (cat broadcast/${{ inputs.forge-deployment-script-file }}/${{ inputs.chain-id }}/${SIG_NAME}-latest.json | jq '.transactions | .[] | select(.transactionType == ("CREATE", "CREATE2")) | "- [\(.contractName)](${{inputs.etherscan-url}}/address/\(.contractAddress)#code): \(.contractAddress)"' | tr -d '"' >> releaseNotes.md)
+          (cat broadcast/${{ inputs.forge-deployment-script-file }}/${{ inputs.chain-id }}/${SIG_NAME}-latest.json | jq '.transactions | .additionalContracts[] | "- [.address](${{inputs.etherscan-url}}/address/\(.address)#code)"' | tr -d '"' >> releaseNotes.md)
+
           gh release edit $LATEST_TAG --notes-file releaseNotes.md

--- a/.github/workflows/solidity-deployment.yml
+++ b/.github/workflows/solidity-deployment.yml
@@ -108,7 +108,7 @@ jobs:
           gh release view $LATEST_TAG --json body -q .body >> releaseNotes.md 
           echo "# Deployment Information:" >> releaseNotes.md
           echo "## ${{ inputs.network }}" >> releaseNotes.md
-          (cat broadcast/${{ inputs.forge-deployment-script-file }}/${{ inputs.chain-id }}/${SIG_NAME}-latest.json | jq '.transactions | .[] | select(.transactionType == ("CREATE", "CREATE2")) | "- [\(.contractName)](${{inputs.etherscan-url}}/address/\(.contractAddress)#code): \(.contractAddress)"' | tr -d '"' >> releaseNotes.md)
-          (cat broadcast/${{ inputs.forge-deployment-script-file }}/${{ inputs.chain-id }}/${SIG_NAME}-latest.json | jq '.transactions | .additionalContracts[] | "- [.address](${{inputs.etherscan-url}}/address/\(.address)#code)"' | tr -d '"' >> releaseNotes.md)
+          (cat broadcast/${{ inputs.forge-deployment-script-file }}/${{ inputs.chain-id }}/${SIG_NAME}-latest.json | jq '.transactions[] | select(.transactionType == ("CREATE", "CREATE2")) | "- [\(.contractName)](${{inputs.etherscan-url}}/address/\(.contractAddress)#code): \(.contractAddress)"' | tr -d '"' >> releaseNotes.md)
+          (cat broadcast/${{ inputs.forge-deployment-script-file }}/${{ inputs.chain-id }}/${SIG_NAME}-latest.json | jq '.transactions[].additionalContracts[] | "- [\(.address)](${{inputs.etherscan-url}}/address/\(.address)#code)"' | tr -d '"' >> releaseNotes.md)
 
           gh release edit $LATEST_TAG --notes-file releaseNotes.md


### PR DESCRIPTION
Include contracts deployed via CREATE2 and/or inside of transaction sub-calls in the Release Notes.