### PR TITLE
feat: auto-release based on version in Cargo.toml

### DIFF
--- a/.github/workflows/auto-release-rust.yml
+++ b/.github/workflows/auto-release-rust.yml
@@ -1,0 +1,44 @@
+name: Rust Auto-Release 
+
+on:
+  workflow_call:
+    inputs:
+      binary-name:
+        description: 'The name of the rust binary that will be used for versioning the release'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with: 
+          fetch-tags: "true"
+          fetch-depth: "0"
+      - name: Create Crate Release (if needed)
+        env:
+            GH_TOKEN: ${{ github.token }}
+        run: |
+            echo "Checking if a new release is needed"
+            # get current version from cargo
+            CARGO_VER="v$(cargo metadata --format-version=1 --no-deps  | jq ".packages[] | select(.name == \"${CARGO_BINARY_NAME}\") | .version" -r)"
+            echo "$CARGO_VER"
+            # get latest version from git tags
+            GIT_VER=$(git describe --tags $(git rev-list --tags --max-count=1))
+            echo "$GIT_VER"
+            if [ "$CARGO_VER" == "$GIT_VER" ]; then
+            echo "# No new release needed" >> $GITHUB_STEP_SUMMARY
+            exit 0
+            else
+                echo "New release needed"
+                gh release create "$CARGO_VER" -t "$CARGO_VER" --generate-notes
+                ## Add the release information to the github actions summary
+                echo "# New Release Created" >> $GITHUB_STEP_SUMMARY
+                echo "Tag: [$CARGO_VER](https://github.com/init4tech/builder/releases/tag/${CARGO_VER})" >> $GITHUB_STEP_SUMMARY
+            fi

--- a/docs/auto-release-rust.md
+++ b/docs/auto-release-rust.md
@@ -1,0 +1,18 @@
+# auto-release-rust.yml
+
+## Base Usage
+
+```yml
+create-release:
+  uses: init4tech/actions/.github/workflows/auto-release-rust.yml@main
+  with:
+    binary-name: "my-binary"
+```
+
+## Required Parameters
+
+### `binary-name`
+
+**Description:** The name of the binary (from `Cargo.toml`) that should be used for picking the version of the release
+
+**Type**: `string`

--- a/examples/example-auto-release-rust.yml
+++ b/examples/example-auto-release-rust.yml
@@ -1,35 +1,18 @@
-name: Release and Deploy Contract
+name: Create Rust Release
 # This workflow will create a new tag and release and upload the binary named 'my-binary' to the release on every push to main
 
 on:
   push:
     branches:
     - main
-  workflow_dispatch:
-    inputs: # these inputs are here to allow for manual triggering of releases with custom tags
-      generate-tag:
-        description: 'Generate a new tag'
-        required: true
-        default: 'true'
-      custom-tag:
-        description: 'Custom tag to be used if generate-tag is false'
-        required: false
-        default: ''
+    files:
+    - 'Cargo.toml'
 
 permissions: # these permissions are required for the actions to run
-  packages: write
   contents: write
 
 jobs:
   auto-release: # this job will create a new tag and release
     uses: init4tech/actions/.github/workflows/auto-release.yml@main
     with:
-      generate-tag: true
-      custom-tag: ${{ github.event.inputs.custom-tag }}
-  release-bin:
-    uses: init4tech/actions/.github/workflows/release-rust-bin.yml@main
-    needs: auto-release
-    with:
-      binary-name: 'my-binary'
-      tag: ${{ needs.auto-release.outputs.GENERATED_TAG }}
-
+      binary-name: 'my-binary' # the name of the binary that will be used for versioning the release


### PR DESCRIPTION
### TL;DR
Added a new reusable GitHub Action workflow for automatically creating releases based on Rust crate versions.

### What changed?
- Created a new workflow `auto-release-rust.yml` that compares Cargo.toml version against Git tags
  - Workflow automatically creates GitHub releases when crate version differs from latest tag
- Added documentation explaining workflow usage and parameters
- Updated example workflow to demonstrate implementation


### How to test?
1. Add workflow to your Rust project's CD:
```yml
create-release:
  uses: init4tech/actions/.github/workflows/auto-release-rust.yml@main
  with:
    binary-name: "your-crate-name"
```
2. Update version in Cargo.toml
3. Push changes to trigger workflow
4. Verify new release is created with correct version tag