### PR TITLE
fix: specify a file for when there is nonprivate deps

### DIFF
--- a/.github/workflows/ecr-build-and-push.yml
+++ b/.github/workflows/ecr-build-and-push.yml
@@ -103,6 +103,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64
           context: .
+          file: ${{ inputs.dockerfile-path }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
         env: 


### PR DESCRIPTION
In the case where the user specifies a docker file and does not specify that they need private deps it was not using the `dockerfile-path` input to specify a dockerfile instead relied on the default file.
