### PR TITLE
feat: configure FOUNDRY_PROFILE in solidity base CI

### DIFF
--- a/.github/workflows/solidity-base.yml
+++ b/.github/workflows/solidity-base.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: 1
         type: number
+      foundry-profile:
+        description: 'Foundry profile to use for testing'
+        required: false
+        default: 'ci'
+        type: string
 
 permissions:
   actions: read
@@ -21,7 +26,7 @@ permissions:
   repository-projects: read
 
 env:
-  FOUNDRY_PROFILE: ci
+  FOUNDRY_PROFILE: ${{ inputs.foundry-profile }}
 
 jobs:
   check:

--- a/docs/solidity-base.md
+++ b/docs/solidity-base.md
@@ -24,3 +24,11 @@ solidity-base:
 **Type**: `number`
 
 **Default Value:** `1`
+
+### `foundry-profile`
+
+**Description:** Sets the FOUNDRY_PROFILE env variable for all forge steps (build, format, test) except for generating the gas report, which always uses FOUNDRY_PROFILE=snapshot.
+
+**Type**: `string`
+
+**Default Value:** `ci`


### PR DESCRIPTION
Set FOUNDRY_PROFILE .env variable as a configurable input to Solidity Base CI workflow.