### PR TITLE
feat: optionally set fork url for Forge tests

### DIFF
--- a/.github/workflows/solidity-base.yml
+++ b/.github/workflows/solidity-base.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: 'ci'
         type: string
+      fork-url:
+        description: 'Fork URL to use for Fork testing.'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   actions: read
@@ -55,9 +60,17 @@ jobs:
         id: fmt
 
       - name: Run Forge tests
+        if: ${{ inputs.fork-url == '' }}
         run: |
           forge test -vvv
         id: test
+
+      - name: Run Fork tests
+        if: ${{ inputs.fork-url != '' }}
+        run: |
+          forge test -vvv --fork-url ${{ inputs.fork-url }}
+        id: fork-test
+
       # do not run if disable-gas-snapshot is true
       - name: Compare gas reports
         if: ${{ !inputs.disable-gas-snapshot }}

--- a/docs/solidity-base.md
+++ b/docs/solidity-base.md
@@ -32,3 +32,11 @@ solidity-base:
 **Type**: `string`
 
 **Default Value:** `ci`
+
+### `fork-url`
+
+**Description:** If set, skips local Forge tests and instead runs Forge tests with `--fork-url` flag passing in the provided RPC URL. Repos implementing fork tests can create a Foundry profile that specifies the path of the fork tests, and run the solidity-base workflow passing in `foundry-profile` and `fork-url` tags.
+
+**Type**: `string`
+
+**Default Value:** ``


### PR DESCRIPTION
Optionally set `--fork-url` flag for Forge tests in Solidity Base repo.