### PR TITLE
fix: use our runner group

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -13,7 +13,8 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: 
+      group: init4-runners
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
Changes from public runners to our private runner group for the ghcr workflow. needed as arm is only for public repos without being inside a runner group