### PR TITLE
chore: apply latest label to release builds

### DIFF
--- a/.github/workflows/ecr-build-and-push.yml
+++ b/.github/workflows/ecr-build-and-push.yml
@@ -91,7 +91,7 @@ jobs:
           images: ${{ secrets.aws-ecr-repository }}/${{ inputs.rust-binary-name }}
           tags: |
             type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=true
             type=semver,pattern={{version}}
             type=sha,format=short
       - name: Build and push

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -49,7 +49,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=true
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/.github/workflows/release-docker-ghcr.yml
+++ b/.github/workflows/release-docker-ghcr.yml
@@ -44,7 +44,7 @@ jobs:
               type=semver,pattern={{version}}
               type=semver,pattern={{major}}.{{minor}}
               type=sha
-              type=raw,value=latest,enable={{is_default_branch}}
+              type=raw,value=latest,enable=true
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3
         - name: Login to GitHub Container Registry


### PR DESCRIPTION
This should cause the `latest` label to be applied to tagged release builds as well as the git tag.