### PR TITLE
Add no-default-features clippy to rust-base

### DIFF
--- a/.github/workflows/rust-base.yml
+++ b/.github/workflows/rust-base.yml
@@ -147,6 +147,16 @@ jobs:
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cargo clippy --all-targets --all-features --workspace --profile ${{ inputs.rust-profile }} -- -D warnings
+      - if: ${{ inputs.require-lockfile == true }}
+        name: Clippy check (no-default-features)
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
+        run: cargo clippy --lib --bins --no-default-features --workspace --locked --profile ${{ inputs.rust-profile }} -- -D warnings
+      - if: ${{ inputs.require-lockfile == false }}
+        name: Clippy check (no-default-features)
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
+        run: cargo clippy --lib --bins --no-default-features --workspace --profile ${{ inputs.rust-profile }} -- -D warnings
 
   dylint:
     name: Dylint


### PR DESCRIPTION
## Summary
- The existing `clippy` step in `rust-base.yml` uses `--all-targets --all-features`. `--all-targets` pulls dev-dependencies into the compile, and cargo's feature unification means any features those dev-deps activate also get applied to the main crate's compilation — masking `#[cfg(feature = ...)]` errors that a downstream `--no-default-features` consumer would hit.
- Adds two new steps to the existing `clippy` job that run `cargo clippy --lib --bins --no-default-features --workspace -- -D warnings`, deliberately omitting `--all-targets` so dev-deps can't leak feature activations. Folded into the existing job (rather than a separate job) so consuming repos don't pay duplicated checkout/toolchain/cache setup on every run.

### Caveats
- Single workspace-wide invocation. Intra-workspace deps that don't set `default-features = false` on each other can still re-enable defaults, so this doesn't perfectly model a downstream consumer picking one crate in isolation. It does catch the common dev-dep-leak case this PR targets.
- Fail-fast: if the existing `--all-features` clippy step fails, the new `--no-default-features` step is skipped that run. Accepted tradeoff for sharing runner/cache.

### Rollout impact
- Consumers of `rust-base.yml` pick this up on next run. Repos where `--no-default-features` was silently broken will see CI fail until fixed — that is the intent.

## Test plan
- [ ] Merge and observe one downstream repo's CI run executes the new step successfully (or fails meaningfully on a repo with a known feature-gate bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)