### PR TITLE
fix(qwenreview): pass request body via file to avoid ARG_MAX

### DIFF
--- a/.github/workflows/qwenreview.yml
+++ b/.github/workflows/qwenreview.yml
@@ -118,18 +118,18 @@ jobs:
           OIDC=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=qwenreview.swanbots" | jq -r .value)
 
-          BODY=$(jq -n --arg repo "$GITHUB_REPOSITORY" \
-                       --argjson pr "$PR_NUMBER" \
-                       --arg base "$BASE_SHA" --arg head "$HEAD_SHA" \
-                       --rawfile diff "$DIFF_PATH" \
-                       '{repo:$repo, pr_number:$pr, base_sha:$base,
-                         head_sha:$head, diff:$diff, files:[]}')
+          jq -n --arg repo "$GITHUB_REPOSITORY" \
+                --argjson pr "$PR_NUMBER" \
+                --arg base "$BASE_SHA" --arg head "$HEAD_SHA" \
+                --rawfile diff "$DIFF_PATH" \
+                '{repo:$repo, pr_number:$pr, base_sha:$base,
+                  head_sha:$head, diff:$diff, files:[]}' > body.json
 
           RESP=$(curl -sS -o resp.json -w "%{http_code}" \
             -X POST "$SERVICE_URL/reviews" \
             -H "Authorization: Bearer $OIDC" \
             -H "Content-Type: application/json" \
-            -d "$BODY")
+            --data-binary @body.json)
           if [ "$RESP" = "400" ] && [ "$(jq -r '.error // empty' resp.json)" = "diff_too_large" ]; then
             gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
               -f body="qwenreview: PR is too large (>200 KB diff) for automated review."


### PR DESCRIPTION
## Summary

- The qwenreview reusable workflow's submit step builds the JSON request body into a shell variable and passes it on curl's argv (`-d \"\$BODY\"`).
- When the PR diff is large, the rendered argv exceeds Linux's `MAX_ARG_STRLEN` (128 KiB per argument), `execve` fails with `E2BIG`, and bash surfaces it as `Argument list too long` (exit 126). curl never runs.
- Because curl never runs, the qwenreview service's own `diff_too_large` (200 KB) check never gets a chance to respond, so the workflow can't post the \"PR too large\" comment — it just fails CI.
- Fix: write the JSON body to `body.json` and use `--data-binary @body.json`. Payload size is then bounded only by the service's 200 KB limit (which has correct handling), not the kernel's argv limit.

## Repro

Hit on init4tech/qwenreview PR #5 (a Go-rewrite PR — diff is ~6,000 lines):
- Run: https://github.com/init4tech/qwenreview/actions/runs/25238495492
- Failure line: \`/usr/bin/curl: Argument list too long\` → exit 126

## Notes

- The \`gh api ... --input - <<< \"\$BODY\"\` further down (post-review step) is unaffected — \`<<<\` writes to stdin via a temp file, not argv.
- No behavior change for normal-sized diffs.

## Test plan

- [ ] Re-run qwenreview CI on init4tech/qwenreview PR #5 after merge — expect: workflow runs through curl, service returns HTTP 400 \`diff_too_large\`, workflow posts the \"PR is too large\" comment and exits 0.
- [ ] Smoke a small PR through qwenreview to confirm normal-path behavior still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)