### PR TITLE
fix(qwenreview): handle null payload fields on issue_comment trigger

### DIFF
--- a/.github/workflows/qwenreview.yml
+++ b/.github/workflows/qwenreview.yml
@@ -81,12 +81,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          BASE_SHA=$(jq -r .pull_request.base.sha < "$GITHUB_EVENT_PATH" 2>/dev/null \
-            || gh pr view "$PR_NUMBER" --json baseRefOid -q .baseRefOid)
-          HEAD_SHA=$(jq -r .pull_request.head.sha < "$GITHUB_EVENT_PATH" 2>/dev/null \
-            || gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
-          BASE_REF=$(jq -r .pull_request.base.ref < "$GITHUB_EVENT_PATH" 2>/dev/null \
-            || gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
+          BASE_SHA=$(jq -er .pull_request.base.sha < "$GITHUB_EVENT_PATH" 2>/dev/null) \
+            || BASE_SHA=$(gh pr view "$PR_NUMBER" --json baseRefOid -q .baseRefOid)
+          HEAD_SHA=$(jq -er .pull_request.head.sha < "$GITHUB_EVENT_PATH" 2>/dev/null) \
+            || HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
+          BASE_REF=$(jq -er .pull_request.base.ref < "$GITHUB_EVENT_PATH" 2>/dev/null) \
+            || BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
 
           git fetch --no-tags origin "$BASE_REF" "$HEAD_SHA"
           git diff --unified=3 "$BASE_SHA"..."$HEAD_SHA" > diff.patch

--- a/.github/workflows/qwenreview.yml
+++ b/.github/workflows/qwenreview.yml
@@ -89,7 +89,17 @@ jobs:
             || BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
 
           git fetch --no-tags origin "$BASE_REF" "$HEAD_SHA"
-          git diff --unified=3 "$BASE_SHA"..."$HEAD_SHA" > diff.patch
+          # Exclude planning artifacts and generated lockfiles from the diff
+          # sent to the reviewer. These are either non-code (specs/plans) or
+          # machine-generated, and consume budget the model should spend on
+          # actual source changes.
+          git diff --unified=3 "$BASE_SHA"..."$HEAD_SHA" -- \
+            ':(exclude)docs/superpowers/**' \
+            ':(exclude)*.lock' \
+            ':(exclude)go.sum' \
+            ':(exclude)package-lock.json' \
+            ':(exclude)pnpm-lock.yaml' \
+            > diff.patch
 
           echo "base_sha=$BASE_SHA"   >> "$GITHUB_OUTPUT"
           echo "head_sha=$HEAD_SHA"   >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Two related fixes to the qwenreview reusable workflow's Collect step. Both target the `init4tech/qwenreview` Go-rewrite PR (#5) failure path but address independent bugs.

## 1. `jq -er` for null payload fields on issue_comment trigger

The Collect step pulled BASE_SHA / HEAD_SHA / BASE_REF from `$GITHUB_EVENT_PATH` with `jq -r ...` and a `gh pr view` fallback gated on jq's exit code. For the `/qwenreview` issue_comment trigger the payload has no `pull_request` key, so `jq -r` printed the literal string `null` and exited 0 — the fallback never fired and `git fetch ... null null` blew up.

Fix: switch to `jq -er` so jq exits non-zero on null/false, and lift the `||` outside the `$()` so the fallback's stdout (not jq's `"null"` line) lands in the variable.

Failing run: https://github.com/init4tech/qwenreview/actions/runs/25238720402/job/74010447040

## 2. Exclude planning artifacts and lockfiles from the diff

The 200 KB service cap rejects PRs whose bulk is documentation. Concrete case: the Go-rewrite PR is **286 KB**, of which **115 KB** lives in two files under `docs/superpowers/` (a Claude Code plan + spec); only **167 KB** is real source change.

Filter the diff in Collect to drop:
- `docs/superpowers/**` — Claude Code planning artifacts (specs/plans)
- `*.lock`, `go.sum`, `package-lock.json`, `pnpm-lock.yaml` — generated lockfiles

Reviewing those is wasted budget. Filtering brings real-world doc-heavy PRs back under the existing 200 KB cap, so no service-side change required.

| Diff variant | Size |
|---|---:|
| Full PR #5 diff | 286 KB |
| With these excludes | **167 KB** ✓ |

## Verification

Tested end-to-end against the local Python qwenreview service via the cloudflared tunnel.

**Test setup:** init4tech/qwenreview test PR #6, branch points at this fix branch via `uses: ...@fix/qwenreview-collect-null-handling`. The branch includes a bait file at `docs/superpowers/_test-filter-check.md` containing made-up identifiers (`frobnicate_review_payload`, `LLAMA_HEX_PROTOCOL`) the reviewer would surely comment on if it saw them.

Run: https://github.com/init4tech/qwenreview/actions/runs/25239197196

Result:
- All 7 workflow steps green: Eligibility, Collect, Mint token, Submit, Poll, Post review
- Review posted on the workflow ref change only
- **Zero bait-file leakage**: review body and line-level comments contain no reference to the bait file or its bait phrases
- Line-level comments scoped to `.github/workflows/qwenreview.yml` only

Local `jq` verification (jq 1.7) confirmed:
- `jq -r .pull_request.base.sha` → `null` + exit 0 (bug)
- `jq -er .pull_request.base.sha` → exit 1 → fallback fires (fix)
- No regression on populated `pull_request` payload

## Test plan after merge

- Re-trigger via `/qwenreview` comment on init4tech/qwenreview#5. Expected: collect step succeeds, filter drops `docs/superpowers/**`, diff is ~167 KB (under 200 KB), service accepts and a real review is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)