### PR TITLE
build(deps): bump cargo-dylint and dylint-link from 5.0.0 to 6.0.3

### DIFF
--- a/.github/workflows/rust-base.yml
+++ b/.github/workflows/rust-base.yml
@@ -192,12 +192,12 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: cargo-dylint@5.0.0
+          tool: cargo-dylint@6.0.3
       - name: Install dylint-link
         if: steps.check.outputs.skip != 'true'
         uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: dylint-link@5.0.0
+          tool: dylint-link@6.0.3
       - name: Checkout lints
         if: steps.check.outputs.skip != 'true'
         uses: actions/checkout@v6


### PR DESCRIPTION
The dylint ABI version (`DYLINT_VERSION`) is unchanged at "0.1.0" between v5.0.0 and v6.0.3, so the lint library in init4tech/lints keeps loading without a companion bump of `dylint_linting`. The driver also still gates support for nightlies older than 2026-03-18, so the pinned nightly-2026-03-17 remains supported.