### PR TITLE
fix(ci): unblock dylint on higher-MSRV workspaces, bump dylint to 6.0.3

### DIFF
--- a/.github/workflows/rust-base.yml
+++ b/.github/workflows/rust-base.yml
@@ -225,7 +225,11 @@ jobs:
           DYLINT_LIBRARY_PATH: ${{ github.workspace }}/.lints/instrument-fields/target/debug
           RUSTFLAGS: "-D bare_instrument_fields"
           CARGO_NET_GIT_FETCH_WITH_CLI: true
-        run: cargo +${{ env.NIGHTLY }} dylint --all --no-deps --workspace
+        # The pinned nightly is an implementation detail of the lint tooling, not a
+        # build target, so the inner `cargo check` must not enforce the consuming
+        # workspace's `rust-version`. MSRV is enforced by the Clippy/Test jobs, which
+        # run on the real toolchain.
+        run: cargo +${{ env.NIGHTLY }} dylint --all --no-deps --workspace -- --ignore-rust-version
 
   docs:
     name: Docs

--- a/.github/workflows/rust-base.yml
+++ b/.github/workflows/rust-base.yml
@@ -192,12 +192,12 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: cargo-dylint@5.0.0
+          tool: cargo-dylint@6.0.3
       - name: Install dylint-link
         if: steps.check.outputs.skip != 'true'
         uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: dylint-link@5.0.0
+          tool: dylint-link@6.0.3
       - name: Checkout lints
         if: steps.check.outputs.skip != 'true'
         uses: actions/checkout@v6


### PR DESCRIPTION
Two changes to the Dylint job in `rust-base.yml`: a version bump, and a fix for a real failure the bump does *not* address.

## 1. Bump `cargo-dylint` / `dylint-link` 5.0.0 → 6.0.3

Latest on crates.io (published 2026-08-01). Compatibility checked against dylint's source rather than assumed:

- **The lint library keeps loading unchanged.** The driver enforces `dylint_version == DYLINT_VERSION` at load time (`driver/src/lib.rs:64-72`), but `DYLINT_VERSION` is a hardcoded ABI string, `"0.1.0"`, identical at `v5.0.0` and `v6.0.3`. So `init4tech/lints` can stay on `dylint_linting = "5.0.0"` — no companion PR needed there.
- **The pinned nightly is still supported.** `nightly-2026-03-17` sits just under the driver's newest cutover gate (`before(2026-03-18)` / `since(2026-03-18)`), and 6.0.3 still carries gates back to 2023.
- **6.0.0's breaking changes don't touch this job.** They were removing the `cargo-lib` feature and `--path` library refs (5.0.0), and dropping the MSRV policy (6.0.0). This job uses `DYLINT_LIBRARY_PATH` with `cargo dylint --all --no-deps --workspace`, which is unaffected.

Note that Dependabot will not track these pins going forward — `dependabot.yml` only watches `github-actions`, which covers `taiki-e/cache-cargo-install-action@v3` but not the `tool:` versions passed to it.

## 2. Stop dylint enforcing the consumer workspace's MSRV

This is the part that actually unblocks CI. `init4tech/jay#1` fails its Dylint job with:

```
error: rustc 1.96.0-nightly is not supported by the following packages:
  jay@0.1.0 requires rustc 1.97
  jay-client@0.1.0 requires rustc 1.97
Error: Compilation failed with toolchain `nightly-2026-03-17-aarch64-unknown-linux-gnu`
```

The job pins `NIGHTLY: nightly-2026-03-17` (rustc 1.96.0-nightly); `jay` declares `rust-version = "1.97"`. Cargo's MSRV gate rejects the workspace *before any lint runs* — the log shows the lint library loaded and the driver built fine, then `cargo check` refused to start. The version bump above does not help here; the error comes from cargo, not dylint.

This is new-repo fallout rather than a regression: `jay` is the first consumer whose MSRV outran the pinned nightly.

The fix forwards `--ignore-rust-version` to the inner `cargo check`. dylint passes trailing args after `--` straight through (`cargo-dylint/src/main.rs:66`, `#[clap(last = true, help = "Arguments for cargo check")]`), and the flag is stable on `cargo check`. The nightly exists only to build and load the lint library — it isn't a build target, so it shouldn't gate on the consumer's MSRV, which the Clippy and Test jobs already enforce on the real stable toolchain.

### Why not just bump the nightly

Considered and rejected as the primary fix:

- It needs a coordinated `init4tech/lints` change. `NIGHTLY` mirrors that repo's `rust-toolchain.toml`, and its `dylint_linting = "5.0.0"` (Oct 2025) would then compile against five months of shifted `rustc_private` APIs, so `dylint_linting`/`dylint_testing` would have to move too.
- It re-arms the same trap — the next repo to bump MSRV past the new pin breaks again.

If we do want the nightly moved regardless, `nightly-2026-04-16` is the first `1.97.0-nightly` (verified against `static.rust-lang.org` release manifests). That's separate maintenance, and it still wants `--ignore-rust-version` underneath it.

## Unrelated observation

`RUSTFLAGS: -D bare_instrument_fields` leaks into the driver build, producing `warning[E0602]: unknown lint` since the lint library isn't loaded at that point. Harmless today, but it would turn fatal if that build ever gains `-D warnings`. Not fixed here.

## Testing

Not exercisable from this repo — the Dylint job only runs against consuming workspaces. Real validation is `init4tech/jay#1` going green once this lands on `main`, which is the ref its workflow tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
